### PR TITLE
Fix bug where options pages with a custom post_id weren't getting matched to their translated version

### DIFF
--- a/classes/helpers.php
+++ b/classes/helpers.php
@@ -1,0 +1,18 @@
+<?php namespace BEA\ACF_Options_For_Polylang;
+
+class Helpers {
+	/**
+	 * Get the original option id without language attributes
+	 *
+	 * @param $post_id
+	 *
+	 * @author Maxime CULEA
+	 *
+	 * @since  next
+	 *
+	 * @return string
+	 */
+	public static function original_option_id( $post_id ) {
+		return str_replace( sprintf( '_%s', pll_current_language( 'locale' ) ), '', $post_id );
+	}
+}

--- a/classes/main.php
+++ b/classes/main.php
@@ -89,13 +89,7 @@ class Main {
 		remove_filter( 'acf/settings/current_language', [ $this, 'set_current_site_lang' ] );
 		remove_filter( 'acf/load_value', [ $this, 'get_default_value' ] );
 
-		/**
-		 * Generate the all language option's post_id key
-		 *
-		 * @since  1.0.2
-		 * @author Maxime CULEA
-		 */
-		$all_language_post_id = str_replace( sprintf( '_%s', pll_current_language( 'locale' ) ), '', $post_id );
+		$post_id = Helpers::original_option_id( $post_id );
 
 		// Get the "All language" value
 		$value = acf_get_metadata( $all_language_post_id, $field['name'] );
@@ -132,9 +126,7 @@ class Main {
 	 * @return bool
 	 */
 	function is_option_page( $post_id ) {
-		// Strip any locale from the end of the post_id so it matches post_id's that had their locale appended already
-		$post_id = str_replace( sprintf( '_%s', pll_current_language( 'locale' ) ), '', $post_id );
-
+		$post_id = Helpers::original_option_id( $post_id );
 		if ( false !== strpos( $post_id, 'options' ) ) {
 			return true;
 		}

--- a/classes/main.php
+++ b/classes/main.php
@@ -98,7 +98,7 @@ class Main {
 		$all_language_post_id = str_replace( sprintf( '_%s', pll_current_language( 'locale' ) ), '', $post_id );
 
 		// Get the "All language" value
-		$value = acf_get_metadata( $all_language_post_id, $field['name'] );
+		$value = get_field( $field['name'], $all_language_post_id );
 
 		/**
 		 * Re-add deleted filters
@@ -118,21 +118,7 @@ class Main {
 	 * @return array
 	 */
 	function get_option_page_ids() {
-		if ( ! function_exists( 'acf_get_valid_location_rule' ) ) {
-			return [];
-		}
-		$rule = [
-			'param'    => 'options_page',
-			'operator' => '==',
-			'value'    => 'acf-options',
-			'id'       => 'rule_0',
-			'group'    => 'group_0',
-		];
-
-		$rule          = acf_get_valid_location_rule( $rule );
-		$options_pages = acf_get_location_rule_values( $rule );
-
-		return empty( $options_pages ) ? [] : array_keys( $options_pages );
+		return wp_list_pluck( acf_options_page()->get_pages(), 'post_id' );
 	}
 
 	/**
@@ -146,6 +132,9 @@ class Main {
 	 * @return bool
 	 */
 	function is_option_page( $post_id ) {
+		// Strip any locale from the end of the post_id so it matches post_id's that had their locale appended already
+		$post_id = str_replace( sprintf( '_%s', pll_current_language( 'locale' ) ), '', $post_id );
+
 		if ( false !== strpos( $post_id, 'options' ) ) {
 			return true;
 		}

--- a/classes/main.php
+++ b/classes/main.php
@@ -98,7 +98,7 @@ class Main {
 		$all_language_post_id = str_replace( sprintf( '_%s', pll_current_language( 'locale' ) ), '', $post_id );
 
 		// Get the "All language" value
-		$value = get_field( $field['name'], $all_language_post_id );
+		$value = acf_get_metadata( $all_language_post_id, $field['name'] );
 
 		/**
 		 * Re-add deleted filters


### PR DESCRIPTION
I had an options created with this:
```
acf_add_options_page(array(
    'page_title' => 'Settings',
    'post_id' => 'appearance',
    'menu_slug' => 'nf-appearance-settings',
    'parent_slug' => 'themes.php',
    'capability' => 'manage_options',
));
```
but calling `get_field('footer_columns', 'appearance')` wouldn't match to the translated version, and in wp-admin the content was the same regardless of what Polylang language was selected.

Main changes:

- fetch options page ids properly (function was returning their `menu_slug`'s previously)
- call `get_field()` when fetching the default "All languages" version so that repeaters and stuff are parsed properly