### PR TITLE
Prevent error when using an object ($post) as the second param in get…

### DIFF
--- a/classes/main.php
+++ b/classes/main.php
@@ -181,6 +181,9 @@ class Main {
 	 * @return bool
 	 */
 	function is_option_page( $post_id ) {
+		if ( is_object($post_id) ) {
+			return false;
+		}
 		if ( false !== strpos( $post_id, 'options' ) ) {
 			return true;
 		}


### PR DESCRIPTION
…_field.

<!--
Thanks for contributing !

Please note :
- These comments won't show up when you submit the pull request.
- Please make sure your changes respect the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards).
- In case you introduced a new action or filter hook, please also include [inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php).
- Please provide tests, if you can.
-->

This pull request fixes issue #29.

It will apply the following changes :

* Allow an object such as a WordPress post to be used as the second param in get_field.