### PR TITLE
Fix wrong constant name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.1.5 - 11 Dec 2018
+* FIX wrong constant
+
 ## 1.1.4 - 13 Nov 2018
 * Refactor by adding the Helpers class
 * FEATURE [#26](https://github.com/BeAPI/acf-options-for-polylang/issues/26) : allow to precise to show or hide default values for a specific option page

--- a/bea-acf-options-for-polylang.php
+++ b/bea-acf-options-for-polylang.php
@@ -2,7 +2,7 @@
 
 /*
  Plugin Name: BEA - ACF Options for Polylang
- Version: 1.1.4
+ Version: 1.1.5
  Plugin URI: https://github.com/BeAPI/acf-options-for-polylang
  Description: Add ACF options page support for Polylang.
  Author: Be API Technical team
@@ -34,7 +34,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Plugin constants
-define( 'BEA_ACF_OPTIONS_FOR_POLYLANG_VERSION', '1.1.4' );
+define( 'BEA_ACF_OPTIONS_FOR_POLYLANG_VERSION', '1.1.5' );
 define( 'BEA_ACF_OPTIONS_FOR_POLYLANG_MIN_PHP_VERSION', '5.6' );
 
 // Plugin URL and PATH
@@ -45,7 +45,7 @@ define( 'BEA_ACF_OPTIONS_FOR_POLYLANG_PLUGIN_DIRNAME', basename( rtrim( dirname(
 
 // Check PHP min version
 if ( version_compare( PHP_VERSION, BEA_ACF_OPTIONS_FOR_POLYLANG_MIN_PHP_VERSION, '<' ) ) {
-	require_once( BEA_PB_DIR . 'compat.php' );
+	require_once( BEA_ACF_OPTIONS_FOR_POLYLANG_DIR . 'compat.php' );
 	// possibly display a notice, trigger error
 	add_action( 'admin_init', array( 'BEA\PB\Compatibility', 'admin_init' ) );
 	// stop execution of this file

--- a/compat.php
+++ b/compat.php
@@ -1,4 +1,6 @@
-<?php namespace BEA\ACF_Options_For_Polylang;
+<?php
+
+namespace BEA\ACF_Options_For_Polylang;
 
 class Compatibility {
 	/**


### PR DESCRIPTION
<!--
Thanks for contributing !

Please note :
- These comments won't show up when you submit the pull request.
- Please make sure your changes respect the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards).
- In case you introduced a new action or filter hook, please also include [inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php).
- Please provide tests, if you can.
-->

This pull request fixes issue #{id}.

It will apply the following changes :

* 
* 
* 
