### PR TITLE
Fix call to deprecated acf_get_term_post_id() function (ACF >= 5.9.2)

### DIFF
--- a/classes/helpers.php
+++ b/classes/helpers.php
@@ -22,7 +22,7 @@ class Helpers {
 			} elseif ( isset( $post_id->roles, $post_id->ID ) ) { // user
 				$post_id = 'user_' . $post_id->ID;
 			} elseif ( isset( $post_id->taxonomy, $post_id->term_id ) ) { // term
-				$post_id = acf_get_term_post_id( $post_id->taxonomy, $post_id->term_id );
+				$post_id = 'term_' . $post_id->term_id;
 			} elseif ( isset( $post_id->comment_ID ) ) { // comment
 				$post_id = 'comment_' . $post_id->comment_ID;
 			} else { // default


### PR DESCRIPTION
This pull request fixes issue with ACF >= 5.9.2.
acf_get_term_post_id() function is deprecated since 5.9.2

It will apply the following changes :
* replace `acf_get_term_post_id()` call with `term_{term_id}` string

