### PR TITLE
solving php 8.0.0 warnings

### DIFF
--- a/classes/singleton.php
+++ b/classes/singleton.php
@@ -40,7 +40,7 @@ trait Singleton {
 	 *
 	 * @return void
 	 */
-	final private function __clone() {
+	private function __clone() {
 	}
 
 	/**
@@ -48,6 +48,6 @@ trait Singleton {
 	 *
 	 * @return void
 	 */
-	final private function __wakeup() {
+	public function __wakeup() {
 	}
 }


### PR DESCRIPTION
<!--
Thanks for contributing !

Please note :
- These comments won't show up when you submit the pull request.
- Please make sure your changes respect the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards).
- In case you introduced a new action or filter hook, please also include [inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php).
- Please provide tests, if you can.
-->

This pull request [fixes issue #{63}](https://github.com/BeAPI/acf-options-for-polylang/issues/63).

It will fix the following warnings :

Warning: Private methods cannot be final as they are never overridden by other classes in /wp-content/plugins/acf-options-for-polylang/classes/singleton.php on line 43

Warning: Private methods cannot be final as they are never overridden by other classes in /wp-content/plugins/acf-options-for-polylang/classes/singleton.php on line 51

Warning: The magic method BEA\ACF_Options_For_Polylang\Singleton::__wakeup() must have public visibility in /wp-content/plugins/acf-options-for-polylang/classes/singleton.php on line 51
