### PR TITLE
Use the get_locale function on REST API calls, since pll_current_lang…

### DIFF
--- a/classes/main.php
+++ b/classes/main.php
@@ -30,7 +30,7 @@ class Main {
 	 *
 	 */
 	public function set_current_site_lang() {
-		return pll_current_language( 'locale' );
+		return ! defined( 'REST_API' ) ? pll_current_language( 'locale' ) : \get_locale();
 	}
 
 	/**


### PR DESCRIPTION
This fixes polylang returning `false` on pll_current_language on rest api calls on #59 and #27 .