### PR TITLE
Fix check for ACF 5.6.0 or superior not detecting ACF 5.10.0

### DIFF
--- a/classes/requirements.php
+++ b/classes/requirements.php
@@ -18,7 +18,7 @@ class Requirements {
 			return false;
 		}
 
-		if ( '5.6.0' > acf()->version ) {
+		if ( version_compare( acf()->version, '5.6.0', '>' ) ) {
 			$this->display_error( __( 'Advanced Custom Fields should be on version 5.6.0 or above.', 'bea-acf-options-for-polylang' ) );
 
 			return false;


### PR DESCRIPTION
<!--
Thanks for contributing !

Please note :
- These comments won't show up when you submit the pull request.
- Please make sure your changes respect the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards).
- In case you introduced a new action or filter hook, please also include [inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php).
- Please provide tests, if you can.
-->

It will apply the following changes :

* Remove _Advanced Custom Fields should be on version 5.6.0 or above_ message when on ACF 5.10.
