### PR TITLE
Add support for composer/installers ^2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
 	"license":"GPL-3.0+",
 	"require": {
 		"php": ">=5.6.0",
-		"composer/installers": "~1.0"
+		"composer/installers": "^1.0|^2.0"
 	},
 	"require-dev": {
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",


### PR DESCRIPTION
> Natively Supported Frameworks:
>
> Most frameworks these days natively work with Composer and will be installed to the default vendor directory. composer/installers is not needed to install packages with these frameworks.

https://github.com/composer/installers#a-multi-framework-composer-library-installer