### PR TITLE
suppress deprecated warning on php 8.2.0 because $post_id is null on 404 pages

### DIFF
--- a/classes/helpers.php
+++ b/classes/helpers.php
@@ -15,27 +15,27 @@ class Helpers {
 	 * @author Maxime CULEA
 	 */
 	public static function original_option_id( $post_id ) {
-		// $post_id may be an object
+		// Default value for $post_id
+		$processed_post_id = 0;
+
+		// If $post_id is an object, determine its type
 		if ( is_object( $post_id ) ) {
-			if ( isset( $post_id->post_type, $post_id->ID ) ) { // post
-				$post_id = $post_id->ID;
-			} elseif ( isset( $post_id->roles, $post_id->ID ) ) { // user
-				$post_id = 'user_' . $post_id->ID;
-			} elseif ( isset( $post_id->taxonomy, $post_id->term_id ) ) { // term
-				$post_id = 'term_' . $post_id->term_id;
-			} elseif ( isset( $post_id->comment_ID ) ) { // comment
-				$post_id = 'comment_' . $post_id->comment_ID;
-			} else { // default
-				$post_id = 0;
+			if ( isset( $post_id->post_type, $post_id->ID ) ) {
+				$processed_post_id = $post_id->ID;
+			} elseif ( isset( $post_id->roles, $post_id->ID ) ) {
+				$processed_post_id = 'user_' . $post_id->ID;
+			} elseif ( isset( $post_id->taxonomy, $post_id->term_id ) ) {
+				$processed_post_id = 'term_' . $post_id->term_id;
+			} elseif ( isset( $post_id->comment_ID ) ) {
+				$processed_post_id = 'comment_' . $post_id->comment_ID;
 			}
 		}
 
-		// allow for option == options
-		if ( 'option' === $post_id ) {
-			$post_id = 'options';
-		}
+		// Replace 'option' with 'options'
+		$processed_post_id = ( 'option' === $processed_post_id ) ? 'options' : $processed_post_id;
 
-		return str_replace( sprintf( '_%s', pll_current_language( 'locale' ) ), '', $post_id );
+		// Remove the locale suffix from $processed_post_id
+		return str_replace( sprintf( '_%s', pll_current_language( 'locale' ) ), '', $processed_post_id );
 	}
 
 

--- a/classes/main.php
+++ b/classes/main.php
@@ -55,7 +55,7 @@ class Main {
 		 * Dynamically get the options page ID
 		 * @see : https://regex101.com/r/58uhKg/2/
 		 */
-		$_post_id = preg_replace( '/(_[a-z]{2}_[A-Z]{2})/', '', $post_id );
+		$_post_id = $post_id ? preg_replace( '/(_[a-z]{2}_[A-Z]{2})/', '', $post_id ) : 0;
 
 		remove_filter( 'acf/load_reference', [ $this, 'get_default_reference' ] );
 		$reference = acf_get_reference( $field_name, $_post_id );


### PR DESCRIPTION
<!--
Thanks for contributing !

Please note :
- These comments won't show up when you submit the pull request.
- Please make sure your changes respect the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards).
- In case you introduced a new action or filter hook, please also include [inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php).
- Please provide tests, if you can.
-->

This pull request fixes issue regarding deprecated warnings for php 8 because $post_id is passed null in str_replace and preg_replace.

It will apply the following changes :

* make sure $post_id is always defined in Helpers/original_option_id method
* make sure $post_id is always defined in Main/get_default_reference method
