### PR TITLE
Disable warning in admin UI for excluded option pages

### DIFF
--- a/classes/admin.php
+++ b/classes/admin.php
@@ -25,7 +25,12 @@ class Admin {
 	/**
 	 * Displays context-sensitive help to the user
 	 */
-	public function submitbox_before_major_actions() {
+	public function submitbox_before_major_actions($page) {
+		// If Polylang isn't active for this page, don't display the message
+		if ( ! Helpers::is_option_page( $page['post_id'] ) ) {
+			return;
+		}
+		
 		$current_lang = pll_current_language( 'name' );
 		if ( false !== $current_lang ) {
 			/* translators: %s: current language name */


### PR DESCRIPTION
<!--
Thanks for contributing !

Please note :
- These comments won't show up when you submit the pull request.
- Please make sure your changes respect the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards).
- In case you introduced a new action or filter hook, please also include [inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php).
- Please provide tests, if you can.
-->

It will apply the following changes :

* When an option page is excluded from the multilingual functionality (via the `bea.aofp.excluded_post_ids` filter), we shouldn't show the warning in the UI that the user is editing the options for a certain language.
