### PR TITLE
fix: deprecation warnings

### DIFF
--- a/classes/helpers.php
+++ b/classes/helpers.php
@@ -35,7 +35,7 @@ class Helpers {
 			$post_id = 'options';
 		}
 
-		return str_replace( sprintf( '_%s', pll_current_language( 'locale' ) ), '', $post_id );
+		return $post_id ? str_replace( sprintf( '_%s', pll_current_language( 'locale' ) ), '', $post_id ) : 0;
 	}
 
 

--- a/classes/main.php
+++ b/classes/main.php
@@ -47,7 +47,7 @@ class Main {
 	 *
 	 */
 	public function get_default_reference( $reference, $field_name, $post_id ) {
-		if ( ! empty( $reference ) ) {
+		if ( ! empty( $reference ) || !$post_id ) {
 			return $reference;
 		}
 


### PR DESCRIPTION
- Fixes PHP deprecation warnings
- Prevents several method from being called if non applicable
- Less verbose than #87

@herewithme, is this repo still maintained? Just wondering since there are some open PRs and issues which haven't been touched in a while. Asking to know if I need to patch this deprecation warnings on my own codebase for now. Thanks for the good work!
