### PR TITLE
Fix to support non-conventional locale format through polylang locale detection

### DIFF
--- a/classes/helpers.php
+++ b/classes/helpers.php
@@ -95,7 +95,11 @@ class Helpers {
 	 * @return bool
 	 */
 	public static function already_localized( $post_id ) {
-		preg_match( '/' . self::locales_regex_fragment() . '$/', $post_id, $language );
+		$locales_regex_fragment = self::locales_regex_fragment();
+		if ( ! $locales_regex_fragment ) {
+			return false;
+		}
+		preg_match( '/' . $locales_regex_fragment . '$/', $post_id, $language );
 
 		return ! empty( $language );
 	}
@@ -104,11 +108,16 @@ class Helpers {
 	 * @return string A regex fragment for all polylang configured locales
 	 */
 	public static function locales_regex_fragment(): string {
+		$locales = pll_languages_list( [ 'hide_empty' => false, 'fields' => 'locale' ] );
+		if ( ! $locales ) {
+			return '';
+		}
+
 		return sprintf(
 			'(%s)',
 			implode( '|', array_map( function ( $lang ) {
 				return preg_quote( $lang, '/' );
-			}, pll_languages_list( [ 'hide_empty' => false, 'fields' => 'locale' ] ) ) )
+			}, $locales ) )
 		);
 	}
 }

--- a/classes/helpers.php
+++ b/classes/helpers.php
@@ -95,21 +95,20 @@ class Helpers {
 	 * @return bool
 	 */
 	public static function already_localized( $post_id ) {
-		preg_match( '/'.self::locales_regex_fragment().'$/', $post_id, $language );
+		preg_match( '/' . self::locales_regex_fragment() . '$/', $post_id, $language );
 
 		return ! empty( $language );
 	}
 
-    /**
-     * @return string A regex fragment for all polylang configured locales
-     */
-    public static function locales_regex_fragment(): string
-    {
-        return sprintf(
-            '(%s)',
-            implode('|', array_map(function ($lang) {
-                return preg_quote($lang, '/');
-            }, pll_languages_list(['hide_empty' => false, 'fields' => 'locale'])))
-        );
-    }
+	/**
+	 * @return string A regex fragment for all polylang configured locales
+	 */
+	public static function locales_regex_fragment(): string {
+		return sprintf(
+			'(%s)',
+			implode( '|', array_map( function ( $lang ) {
+				return preg_quote( $lang, '/' );
+			}, pll_languages_list( [ 'hide_empty' => false, 'fields' => 'locale' ] ) ) )
+		);
+	}
 }

--- a/classes/helpers.php
+++ b/classes/helpers.php
@@ -95,8 +95,21 @@ class Helpers {
 	 * @return bool
 	 */
 	public static function already_localized( $post_id ) {
-		preg_match( '/[a-z]{2}_[A-Z]{2}/', $post_id, $language );
+		preg_match( '/'.self::locales_regex_fragment().'$/', $post_id, $language );
 
 		return ! empty( $language );
 	}
+
+    /**
+     * @return string A regex fragment for all polylang configured locales
+     */
+    public static function locales_regex_fragment(): string
+    {
+        return sprintf(
+            '(%s)',
+            implode('|', array_map(function ($lang) {
+                return preg_quote($lang, '/');
+            }, pll_languages_list(['hide_empty' => false, 'fields' => 'locale'])))
+        );
+    }
 }

--- a/classes/helpers.php
+++ b/classes/helpers.php
@@ -99,7 +99,7 @@ class Helpers {
 		if ( ! $locales_regex_fragment ) {
 			return false;
 		}
-		preg_match( '/' . $locales_regex_fragment . '$/', $post_id, $language );
+		preg_match( '/_(' . $locales_regex_fragment . ')$/', $post_id, $language );
 
 		return ! empty( $language );
 	}

--- a/classes/main.php
+++ b/classes/main.php
@@ -47,7 +47,9 @@ class Main {
 	 *
 	 */
 	public function get_default_reference( $reference, $field_name, $post_id ) {
-		if ( ! empty( $reference ) ) {
+		$locales_regex_fragment = Helpers::locales_regex_fragment();
+
+		if ( ! empty( $reference ) || ! $locales_regex_fragment ) {
 			return $reference;
 		}
 
@@ -55,7 +57,7 @@ class Main {
 		 * Dynamically get the options page ID
 		 * @see : https://regex101.com/r/58uhKg/2/
 		 */
-		$_post_id = preg_replace( '/(_' . Helpers::locales_regex_fragment() . ')$/', '', $post_id );
+		$_post_id = preg_replace( '/(_' . $locales_regex_fragment . ')$/', '', $post_id );
 
 		remove_filter( 'acf/load_reference', [ $this, 'get_default_reference' ] );
 		$reference = acf_get_reference( $field_name, $_post_id );
@@ -85,8 +87,8 @@ class Main {
 		/**
 		 * Activate or deactivate the default value (all languages) for the given post id
 		 *
-		 * @param bool $show_default : whatever to show default for the given post id
-		 * @param string $original_post_id : the original post id without lang attributes
+		 * @param  bool  $show_default  : whatever to show default for the given post id
+		 * @param  string  $original_post_id  : the original post id without lang attributes
 		 *
 		 * @since 1.0.4
 		 */
@@ -144,8 +146,8 @@ class Main {
 	/**
 	 * Manage to change the post_id with the current lang to save option against
 	 *
-	 * @param string $future_post_id
-	 * @param string $original_post_id
+	 * @param  string  $future_post_id
+	 * @param  string  $original_post_id
 	 *
 	 * @return string
 	 * @author Maxime CULEA

--- a/classes/main.php
+++ b/classes/main.php
@@ -55,7 +55,7 @@ class Main {
 		 * Dynamically get the options page ID
 		 * @see : https://regex101.com/r/58uhKg/2/
 		 */
-		$_post_id = preg_replace( '/(_'.Helpers::locales_regex_fragment().')$/', '', $post_id );
+		$_post_id = preg_replace( '/(_' . Helpers::locales_regex_fragment() . ')$/', '', $post_id );
 
 		remove_filter( 'acf/load_reference', [ $this, 'get_default_reference' ] );
 		$reference = acf_get_reference( $field_name, $_post_id );

--- a/classes/main.php
+++ b/classes/main.php
@@ -47,9 +47,11 @@ class Main {
 	 *
 	 */
 	public function get_default_reference( $reference, $field_name, $post_id ) {
-		$locales_regex_fragment = Helpers::locales_regex_fragment();
+		if ( ! empty( $reference ) ) {
+			return $reference;
+		}
 
-		if ( ! empty( $reference ) || ! $locales_regex_fragment ) {
+		if ( ! $locales_regex_fragment = Helpers::locales_regex_fragment() ) {
 			return $reference;
 		}
 

--- a/classes/main.php
+++ b/classes/main.php
@@ -55,7 +55,7 @@ class Main {
 		 * Dynamically get the options page ID
 		 * @see : https://regex101.com/r/58uhKg/2/
 		 */
-		$_post_id = preg_replace( '/(_[a-z]{2}_[A-Z]{2})/', '', $post_id );
+		$_post_id = preg_replace( '/(_'.Helpers::locales_regex_fragment().')$/', '', $post_id );
 
 		remove_filter( 'acf/load_reference', [ $this, 'get_default_reference' ] );
 		$reference = acf_get_reference( $field_name, $_post_id );


### PR DESCRIPTION
This pull request fixes issue #50.

It will apply the following changes :

* Replace locale detection regex in two places with a dynamic regex based on Polylang locales

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves locale handling by deriving a regex from configured Polylang locales instead of assuming `xx_XX`.
> 
> - Add `Helpers::locales_regex_fragment()` to build an escaped, joined locales regex
> - Update `Helpers::already_localized()` and `Main::get_default_reference()` to use the dynamic regex and match only trailing `_<locale>`
> - Guard with early return when no locales are available
> - Minor docblock formatting adjustments
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d56e3da7a912a39467448a7f0c9a29cbe30a8514. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->