### PR TITLE
Add a filter to allow modification of the activation behavior for default values

### DIFF
--- a/classes/helpers.php
+++ b/classes/helpers.php
@@ -95,21 +95,20 @@ class Helpers {
 	 * @return bool
 	 */
 	public static function already_localized( $post_id ) {
-		preg_match( '/'.self::locales_regex_fragment().'$/', $post_id, $language );
+		preg_match( '/' . self::locales_regex_fragment() . '$/', $post_id, $language );
 
 		return ! empty( $language );
 	}
 
-    /**
-     * @return string A regex fragment for all polylang configured locales
-     */
-    public static function locales_regex_fragment(): string
-    {
-        return sprintf(
-            '(%s)',
-            implode('|', array_map(function ($lang) {
-                return preg_quote($lang, '/');
-            }, pll_languages_list(['hide_empty' => false, 'fields' => 'locale'])))
-        );
-    }
+	/**
+	 * @return string A regex fragment for all polylang configured locales
+	 */
+	public static function locales_regex_fragment(): string {
+		return sprintf(
+			'(%s)',
+			implode( '|', array_map( function ( $lang ) {
+				return preg_quote( $lang, '/' );
+			}, pll_languages_list( [ 'hide_empty' => false, 'fields' => 'locale' ] ) ) )
+		);
+	}
 }

--- a/classes/helpers.php
+++ b/classes/helpers.php
@@ -95,8 +95,21 @@ class Helpers {
 	 * @return bool
 	 */
 	public static function already_localized( $post_id ) {
-		preg_match( '/[a-z]{2}_[A-Z]{2}/', $post_id, $language );
+		preg_match( '/'.self::locales_regex_fragment().'$/', $post_id, $language );
 
 		return ! empty( $language );
 	}
+
+    /**
+     * @return string A regex fragment for all polylang configured locales
+     */
+    public static function locales_regex_fragment(): string
+    {
+        return sprintf(
+            '(%s)',
+            implode('|', array_map(function ($lang) {
+                return preg_quote($lang, '/');
+            }, pll_languages_list(['hide_empty' => false, 'fields' => 'locale'])))
+        );
+    }
 }

--- a/classes/main.php
+++ b/classes/main.php
@@ -55,7 +55,7 @@ class Main {
 		 * Dynamically get the options page ID
 		 * @see : https://regex101.com/r/58uhKg/2/
 		 */
-		$_post_id = preg_replace( '/(_'.Helpers::locales_regex_fragment().')$/', '', $post_id );
+		$_post_id = preg_replace( '/(_' . Helpers::locales_regex_fragment() . ')$/', '', $post_id );
 
 		remove_filter( 'acf/load_reference', [ $this, 'get_default_reference' ] );
 		$reference = acf_get_reference( $field_name, $_post_id );

--- a/classes/main.php
+++ b/classes/main.php
@@ -76,7 +76,14 @@ class Main {
 	 *
 	 */
 	public function get_default_value( $value, $post_id, $field ) {
-		if ( ! acf_is_ajax() && ( is_admin() || ! Helpers::is_option_page( $post_id ) ) ) {
+		$enable = acf_is_ajax() || ! is_admin() && Helpers::is_option_page( $post_id );
+
+		/**
+		 * Allow to override default logic for enabling default values
+		 *
+		 * @param  bool  $enable
+		 */
+		if ( ! apply_filters( 'bea.aofp.get_default_enable', $enable, $post_id, $field ) ) {
 			return $value;
 		}
 

--- a/classes/main.php
+++ b/classes/main.php
@@ -55,7 +55,7 @@ class Main {
 		 * Dynamically get the options page ID
 		 * @see : https://regex101.com/r/58uhKg/2/
 		 */
-		$_post_id = preg_replace( '/(_[a-z]{2}_[A-Z]{2})/', '', $post_id );
+		$_post_id = preg_replace( '/(_'.Helpers::locales_regex_fragment().')$/', '', $post_id );
 
 		remove_filter( 'acf/load_reference', [ $this, 'get_default_reference' ] );
 		$reference = acf_get_reference( $field_name, $_post_id );


### PR DESCRIPTION
This pull request fixes issue #98.

It will apply the following changes :

* Add a filter to allow modification of the activation behavior for default values ​​(specifically to allow activation in the administration panel)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - Adds `bea.aofp.get_default_enable` filter in `classes/main.php#get_default_value` to control when default values are enabled (including allowing activation in admin).
> - Replaces hardcoded locale regex with dynamic Polylang-based fragment via new `Helpers::locales_regex_fragment()` and updates locale handling in `Helpers::already_localized` and `Main::get_default_reference` to strip/identify locale suffixes reliably.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5202331b0222e08cacf47648568a2fac41049c3f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->