### PR TITLE
Add a filter for early activation behavior override

### DIFF
--- a/classes/main.php
+++ b/classes/main.php
@@ -76,7 +76,14 @@ class Main {
 	 *
 	 */
 	public function get_default_value( $value, $post_id, $field ) {
-		if ( ! acf_is_ajax() && ( is_admin() || ! Helpers::is_option_page( $post_id ) ) ) {
+		$enable = acf_is_ajax() || ! is_admin() && Helpers::is_option_page( $post_id );
+
+		/**
+		 * Allow to override default logic for enabling default values
+		 *
+		 * @param  bool  $enable
+		 */
+		if ( ! apply_filters( 'bea.aofp.get_default_enable', $enable, $post_id, $field ) ) {
 			return $value;
 		}
 


### PR DESCRIPTION
This pull request fixes issue #98.

It will apply the following changes :

* Add a filter to allow modification of the activation behavior for default values ​​(specifically to allow activation in the administration panel)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces an override for default-value enablement and updates when defaults load.
> 
> - Adds `bea.aofp.get_default_enable` filter in `Main::get_default_value` to allow overriding whether default values should be enabled (args: `$enable`, `$post_id`, `$field`)
> - Refactors enablement logic to enable defaults during AJAX and on admin option pages; early-return now respects the new filter
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 333782878aee65b645ccf2fb00b9a71ae92c8b41. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->