### PR TITLE
fix: use add_action() for ACF options-page submitbox hook

### DIFF
--- a/classes/admin.php
+++ b/classes/admin.php
@@ -12,7 +12,7 @@ class Admin {
 	 * Register hooks
 	 */
 	protected function init() {
-		add_filter(
+		add_action(
 			'acf/options_page/submitbox_before_major_actions',
 			[
 				$this,


### PR DESCRIPTION
## What

`acf/options_page/submitbox_before_major_actions` is fired by ACF Pro via `do_action()`, not `apply_filters()`. The hook registration in `Admin::init()` used `add_filter()`, which is semantically incorrect for an action hook.

**Before:**
```php
add_filter( 'acf/options_page/submitbox_before_major_actions', [ $this, 'submitbox_before_major_actions' ], 10 );
```

**After:**
```php
add_action( 'acf/options_page/submitbox_before_major_actions', [ $this, 'submitbox_before_major_actions' ], 10 );
```

## Why it matters

The `submitbox_before_major_actions` callback echoes output and does not return the `$page` argument — it is action-shaped. WordPress does not error when `add_filter()` is used for a `do_action()` hook, so the current code works today. However, if ACF ever migrates this hook to `apply_filters()`, the page data will be silently lost because the callback returns nothing. Using `add_action()` makes the intent explicit and future-proof.

The fix was confirmed by reading the ACF Pro source (`pro/admin/admin-options-page.php`), which shows `do_action( 'acf/options_page/submitbox_before_major_actions', $page )` at the call site.

---
*Development and testing assisted by AI. All code reviewed and verified manually.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line hook registration change with no logic or output changes; low risk aside from future-proofing hook type.
> 
> **Overview**
> Registers the ACF options-page submitbox callback with **`add_action()`** instead of **`add_filter()`** on `acf/options_page/submitbox_before_major_actions`, matching how ACF Pro fires the hook via `do_action()`.
> 
> Behavior is unchanged today; the callback still only echoes admin notice HTML and does not return `$page`. The change makes the registration action-shaped and avoids silent breakage if ACF ever switches the hook to a filter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2f37314ce9e1094f4b0ebfbe8e0994c55a29512. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->